### PR TITLE
Add an .after method to add callbacks to Factory builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,19 @@ Which returns an object that looks roughly like:
       random_seed:  0.8999513240996748,
       players: [
                     {id: 1, name:'Player 1'},
-                    {id: 1, name:'Player 2'}
+                    {id: 2, name:'Player 2'}
       ]
     }
 
 For a factory with a constructor, if you want just the attributes:
 
     Factory.attributes('game') // return just the attributes
+    
+You can also define a callback function to be run after building an object:
+
+    Factory.define('coach').after(function(coach, options) { if (options.buildPlayer) { Factory.build('player', {coach_id: coach.id}; } })
+    
+    Factory.build('coach', {}, {buildPlayer: true});
 
 ## Credits
 

--- a/spec/javascripts/rosie.spec.js
+++ b/spec/javascripts/rosie.spec.js
@@ -12,7 +12,9 @@ describe('Factory', function() {
       };
 
       beforeEach(function() {
-        Factory.define('thing', Thing).attr('name', 'Thing 1');
+        Factory.define('thing', Thing).attr('name', 'Thing 1').after(function(obj) {
+          obj.afterCalled = true;
+        });
       });
 
       it('should return a new instance of that constructor', function() {
@@ -21,7 +23,11 @@ describe('Factory', function() {
       });
 
       it('should set attributes', function() {
-        expect(Factory.build('thing')).toEqual({name: 'Thing 1'});
+        expect(Factory.build('thing')).toEqual({name: 'Thing 1', afterCalled: true});
+      });
+
+      it('should run callbacks', function() {
+          expect(Factory.build('thing').afterCalled).toBe(true);
       });
     });
 
@@ -42,12 +48,18 @@ describe('Factory', function() {
 
   describe('extend', function() {
     beforeEach(function() {
-      Factory.define('thing').attr('name', 'Thing 1');
+      Factory.define('thing').attr('name', 'Thing 1').after(function(obj) {
+        obj.afterCalled = true;
+      });
       Factory.define('anotherThing').extend('thing').attr('title', 'Title 1');
     });
 
     it('should extend attributes', function() {
-      expect(Factory.build('anotherThing')).toEqual({name:'Thing 1', title:'Title 1'});
+      expect(Factory.build('anotherThing')).toEqual({name:'Thing 1', title:'Title 1', afterCalled: true});
+    });
+
+    it('should extend callbacks', function() {
+      expect(Factory.build('anotherThing').afterCalled).toBe(true);
     });
   });
 


### PR DESCRIPTION
This pull request adds a simple callback so that one can have a little more control over the build process by having direct access to the object after it has been built.  This has the benefit of giving you access to any sequence attributes after they have been created (for example primary key ids).
