### PR TITLE
added buildList to Factory

### DIFF
--- a/spec/javascripts/rosie.spec.js
+++ b/spec/javascripts/rosie.spec.js
@@ -46,6 +46,30 @@ describe('Factory', function() {
     });
   });
 
+  describe('buildList', function () {
+    beforeEach(function() {
+      Factory.define('thing').attr('name', 'Thing 1');
+    });
+
+    it('should return array of objects', function() {
+       expect(Factory.buildList('thing', 10).length).toEqual(10);
+    });
+
+    it('should return array of objects with attributes set', function() {
+      var things = Factory.buildList('thing', 10);
+      for(var i = 0; i < 10; i++) {
+        expect(things[i]).toEqual({name: 'Thing 1'});
+      }
+    });
+
+    it('should return array of objects with attributes set', function() {
+      var things = Factory.buildList('thing', 10, {name:'changed'});
+      for(var i = 0; i < 10; i++) {
+        expect(things[i]).toEqual({name: 'changed'});
+      }
+    });
+  });
+
   describe('extend', function() {
     var Thing = function(attrs) {
       for(var attr in attrs) {

--- a/src/rosie.js
+++ b/src/rosie.js
@@ -75,6 +75,14 @@ Factory.build = function(name, attrs, options) {
   return obj;
 };
 
+Factory.buildList = function(name, size, attrs, options) {
+  var objs = [];
+  for(var i = 0; i < size; i++) {
+    objs.push(Factory.build(name, attrs, options));
+  }
+  return objs;
+};
+
 Factory.attributes = function(name, attrs) {
   return this.factories[name].attributes(attrs);
 };


### PR DESCRIPTION
I often need to work with arrays of objects. I find it handy to have a `buildList` around. This works in a similar fashion to `build_list` in factory_girl https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md#building-or-creating-multiple-records
