### PR TITLE
attr's scope is the factory object, but sequences are not

### DIFF
--- a/src/rosie.js
+++ b/src/rosie.js
@@ -17,7 +17,7 @@ Factory.prototype = {
     callback = callback || function(i) { return i; };
     this.attrs[attr] = function() {
       factory.sequences[attr] = factory.sequences[attr] || 0;
-      return callback(++factory.sequences[attr]);
+      return callback.call(this, ++factory.sequences[attr]);
     };
     return this;
   },


### PR DESCRIPTION
Hey Brandon, funny to run in to you after all these years!

It looks like the scope of an attr callback is the factory object, but sequence callbacks scope is Window.  This fix makes sequence callback's scope to be the factory object as well.
