### PR TITLE
Throw error if the factory being build is not defined.

### DIFF
--- a/spec/javascripts/rosie.spec.js
+++ b/spec/javascripts/rosie.spec.js
@@ -1,3 +1,5 @@
+// Factory = require('../../src/rosie.js').Factory;
+
 describe('Factory', function() {
   afterEach(function() {
     Factory.factories = {};
@@ -42,6 +44,11 @@ describe('Factory', function() {
 
       it('should allow overriding attributes', function() {
         expect(Factory.build('thing', {name:'changed'})).toEqual({name:'changed'});
+      });
+
+      it('throws error if the factory is not defined', function() {
+        expect(function(){Factory.build('nothing')})
+          .toThrow('The "nothing" factory is not defined.');
       });
     });
   });

--- a/src/rosie.js
+++ b/src/rosie.js
@@ -68,6 +68,8 @@ Factory.define = function(name, constructor) {
 };
 
 Factory.build = function(name, attrs, options) {
+  if (! this.factories[name])
+    throw new Error('The "'+name+'" factory is not defined.');
   var obj = this.factories[name].build(attrs);
   for(var i = 0; i < this.factories[name].callbacks.length; i++) {
       this.factories[name].callbacks[i](obj, options);


### PR DESCRIPTION
The current exception is:
     TypeError: Cannot call method 'build' of undefined
which is not very informative.

I tried to run the specs but it was not clear what is the required test environment.
It would be great to extend the package.json like this:

  "scripts": {
    "test": "./node_modules/.bin/mocha"
  },
  "devDependencies": {
    "mocha": "_",
    "mocha-sinon": "_",
    "chai": "_",
    "sinon-chai": "_"
  }

etc. I can help if you tell me how are you running the spec.
