### PR TITLE
Export using UMD boilerplate.

### DIFF
--- a/src/rosie.js
+++ b/src/rosie.js
@@ -428,6 +428,10 @@ Factory.attributes = function(name, attributes, options) {
   return this.factories[name].attributes(attributes, options);
 };
 
-if (typeof exports !== 'undefined') {
+if (typeof exports === 'object' && typeof module !== 'undefined') {
   exports.Factory = Factory;
+} else if (typeof define === 'function' && define.amd) {
+  define([], Factory);
+} else if (this) {
+  this.Factory = Factory;
 }


### PR DESCRIPTION
* Adds support for AMD as module format.
* Fixes potential issues with the CommonJS module format.
* Exports to a global object if all not using AMD or CommonJS (closes #13).