### PR TITLE
Modify `extend` to work on unregistered factories.

### DIFF
--- a/src/rosie.js
+++ b/src/rosie.js
@@ -319,7 +319,7 @@ Factory.prototype = {
    * @return {Factory}
    */
   extend: function(name) {
-    var factory = Factory.factories[name];
+    var factory = (typeof name === 'string') ? Factory.factories[name] : name;
     // Copy the parent's constructor
     if (this.construct === undefined) { this.construct = factory.construct; }
     Factory.util.extend(this.attrs, factory.attrs);


### PR DESCRIPTION
Changes in this PR:

 * Modified the `extend` method on `Factory` to allow for it to work on unregistered factories.
 * Added test coverage for extending unregistered factories.
 * Updated the test coverage to assert that overriding attributes in a child factory works.
