### PR TITLE
amd module definition fix

### DIFF
--- a/src/rosie.js
+++ b/src/rosie.js
@@ -441,7 +441,7 @@ Factory.attributes = function(name, attributes, options) {
 if (typeof exports === 'object' && typeof module !== 'undefined') {
   exports.Factory = Factory;
 } else if (typeof define === 'function' && define.amd) {
-  define([], Factory);
+  define([], function() { return {Factory: Factory}; });
 } else if (this) {
   this.Factory = Factory;
 }


### PR DESCRIPTION
In the [AMD notation](https://github.com/amdjs/amdjs-api/wiki/AMD) if the last argument of `define(...)` is a function, it is considered as `factory` but not as `returned object`.
My simple commit fixes this issue for `rosie`(worked fine with require.js in my project environment)