### PR TITLE
Deprecate inherits.

### DIFF
--- a/src/rosie.js
+++ b/src/rosie.js
@@ -162,6 +162,7 @@ Factory.prototype = {
    * @return {Factory}
    */
   inherits: function(parentFactory) {
+    console.warn('Factory#inherits is deprecated and will be removed in rosie v2. Please use Factory#extends instead.');
     this.construct = function(attributes, options) {
       return Factory.build(parentFactory, attributes, options);
     };

--- a/src/rosie.js
+++ b/src/rosie.js
@@ -162,7 +162,7 @@ Factory.prototype = {
    * @return {Factory}
    */
   inherits: function(parentFactory) {
-    console.warn('Factory#inherits is deprecated and will be removed in rosie v2. Please use Factory#extends instead.');
+    console.warn('Factory#inherits is deprecated and will be removed in rosie v2. Please use Factory#extends instead.'); // eslint-disable-line no-console
     this.construct = function(attributes, options) {
       return Factory.build(parentFactory, attributes, options);
     };


### PR DESCRIPTION
This isn't tested or used by anything else. I'm marking it as a candidate for removal in 2.x.