### PR TITLE
Add attrs convenience function

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Factory.attributes('game'); // return just the attributes
 
 ### Programmatic Generation of Attributes
 
-You can specify options that are used to programatically generate the attributes:
+You can specify options that are used to programmatically generate the attributes:
 
 ```js
 var moment = require('moment');
@@ -106,6 +106,21 @@ Factory.build('matches', { seasonStart: '2016-03-12' }, { numMatches: 3 });
 In the example `numMatches` is defined as an `option`, not as an `attribute`. Therefore `numMatches` is not part of the output, it is only used to generate the `matches` array.
 
 In the same example `seasonStart` is defined as an `attribute`, therefore it appears in the output, and can also be used in the generator function that creates the `matches` array.
+
+### Batch Specification of Attributes
+
+The convenience function `attrs` simplifies the common case of specifying multiple attributes in a batch. Rewriting the `game` example from above:
+
+```js
+Factory.define('game')
+  .sequence('id')
+  .attrs({
+    is_over: false,
+    created_at: function() { return new Date(); }),
+    random_seed: function() { return Math.random(); })
+  })
+  .attr('players', ['players'], function(players) { /* etc. */ })
+```
 
 ### Post Build Callback
 
@@ -211,7 +226,11 @@ import { Factory } from 'rosie';
 
 export default new Factory()
   .sequence('id')
-  .attr('is_over', false);
+  .attrs({
+    is_over: false,
+    created_at: () => new Date(),
+    random_seed: () => Math.random()
+  })
   // etc
 
 // index.js
@@ -235,7 +254,7 @@ Once you have an instance returned from a `Factory.define` or a `new Factory()` 
 #### Factory.define
 
 * **Factory.define(``factory_name``)** - Defines a factory by name. Return an instance of a Factory that you call `.attr`, `.option`, `.sequence`, and `.after` on the result to define the properties of this factory.
-* **Factory.define(`factory_name`, `constructor`)** - Optionally pass a constuctor function, and the objects produced by `.build` will be passed through the `constructor` funtion.
+* **Factory.define(`factory_name`, `constructor`)** - Optionally pass a constuctor function, and the objects produced by `.build` will be passed through the `constructor` function.
 
 
 #### instance.attr:
@@ -245,6 +264,14 @@ Use this to define attributes of your objects
 * **instance.attr(`attribute_name`, `default_value`)** - `attribute_name` is required and is a string, `default_value` is the value to use by default for the attribute
 * **instance.attr(`attribute_name`, `generator_function`)** - `generator_function` is called to generate the value of the attribute
 * **instance.attr(`attribute_name`, `dependencies`, `generator_function`)** - `dependencies` is an array of strings, each string is the name of an attribute or option that is required by the `generator_function` to generate the value of the attribute. This list of `dependencies` will match the parameters that are passed to the `generator_function`
+
+#### instance.attrs:
+
+Use this as a convenience function instead of calling `instance.attr` multiple times
+
+* **instance.attrs(`{attribute_1: value_1, attribute_2: value_2, ...}`)** - `attribute_i` is a string, `value_i` is either an object or generator function.
+
+See `instance.attr` above for details. Note: there is no way to specify dependencies using this method, so if you need that, you should use `instance.attr` instead.
 
 #### instance.option:
 

--- a/spec/javascripts/rosie.spec.js
+++ b/spec/javascripts/rosie.spec.js
@@ -39,9 +39,24 @@ describe('Factory', function() {
         });
 
         it('should pass options to the after callback', function(){
-          expect(Factory.build('thing').isAwesomeOption).toBe(true); 
+          expect(Factory.build('thing').isAwesomeOption).toBe(true);
         });
       });
+
+      describe('using attrs convenience function', function() {
+        beforeEach(function() {
+          Factory.define('thing', Thing).attrs({
+            name: 'Thing 1',
+            attr1: 'value1',
+            attr2: 'value2'
+          });
+        });
+
+        it('should set attributes', function() {
+          var thing = Factory.build('thing');
+          expect(thing).toEqual(jasmine.objectContaining({name: 'Thing 1', attr1: 'value1', attr2: 'value2'}));
+        });
+      })
     });
 
     describe('without a constructor', function() {

--- a/src/rosie.js
+++ b/src/rosie.js
@@ -77,12 +77,14 @@ Factory.prototype = {
    *     age: function() { return Math.random() * 100; }
    *   })
    *
-   * @param {object=} attributes
+   * @param {object} attributes
    * @return {Factory}
    */
   attrs: function(attributes) {
     for (var attr in attributes) {
-      this.attr(attr, attributes[attr]);
+      if (attributes.hasOwnProperty(attr)) {
+        this.attr(attr, attributes[attr]);
+      }
     }
     return this;
   },

--- a/src/rosie.js
+++ b/src/rosie.js
@@ -82,7 +82,7 @@ Factory.prototype = {
    */
   attrs: function(attributes) {
     for (var attr in attributes) {
-      if (attributes.hasOwnProperty(attr)) {
+      if (Factory.util.hasOwnProp(attributes, attr)) {
         this.attr(attr, attributes[attr]);
       }
     }

--- a/src/rosie.js
+++ b/src/rosie.js
@@ -8,7 +8,7 @@
  */
 var Factory = function(constructor) {
   this.construct = constructor;
-  this.attrs = {};
+  this._attrs = {};
   this.opts = {};
   this.sequences = {};
   this.callbacks = [];
@@ -62,7 +62,28 @@ Factory.prototype = {
     }
 
     builder = typeof value === 'function' ? value : function() { return value; };
-    this.attrs[attr] = { dependencies: dependencies || [], builder: builder };
+    this._attrs[attr] = { dependencies: dependencies || [], builder: builder };
+    return this;
+  },
+
+  /**
+   * Convenience function for defining a set of attributes on this object as
+   * builder functions or static values. If you need to specify dependencies,
+   * use #attr instead.
+   *
+   * For example:
+   *   Factory.define('Person').attrs({
+   *     name: 'Michael',
+   *     age: function() { return Math.random() * 100; }
+   *   })
+   *
+   * @param {object=} attributes
+   * @return {Factory}
+   */
+  attrs: function(attributes) {
+    for (var attr in attributes) {
+      this.attr(attr, attributes[attr]);
+    }
     return this;
   },
 
@@ -181,7 +202,7 @@ Factory.prototype = {
   attributes: function(attributes, options) {
     attributes = Factory.util.extend({}, attributes);
     options = this.options(options);
-    for (var attr in this.attrs) {
+    for (var attr in this._attrs) {
       this._attrValue(attr, attributes, options, [attr]);
     }
     return attributes;
@@ -203,7 +224,7 @@ Factory.prototype = {
       return attributes[attr];
     }
 
-    var value = this._buildWithDependencies(this.attrs[attr], function(dep) {
+    var value = this._buildWithDependencies(this._attrs[attr], function(dep) {
       if (Factory.util.hasOwnProp(options, dep)) {
         return options[dep];
       } else if (dep === attr) {
@@ -227,7 +248,7 @@ Factory.prototype = {
    * @return {boolean}
    */
   _alwaysCallBuilder: function(attr) {
-    var attrMeta = this.attrs[attr];
+    var attrMeta = this._attrs[attr];
     return attrMeta.dependencies.indexOf(attr) >= 0;
   },
 
@@ -331,7 +352,7 @@ Factory.prototype = {
     var factory = (typeof name === 'string') ? Factory.factories[name] : name;
     // Copy the parent's constructor
     if (this.construct === undefined) { this.construct = factory.construct; }
-    Factory.util.extend(this.attrs, factory.attrs);
+    Factory.util.extend(this._attrs, factory._attrs);
     Factory.util.extend(this.opts, factory.opts);
     // Copy the parent's callbacks
     this.callbacks = factory.callbacks.slice();


### PR DESCRIPTION
- convenience for calling .attr(‘key1’, val1).attr(‘key2’, val2)
- Rename attrs property to _attrs to avoid conflict

I think this makes the library a lot more convenient for the common case. Let me know if you want to rename etc.