### PR TITLE
Use deep cloning on build

### DIFF
--- a/spec/javascripts/rosie.spec.js
+++ b/spec/javascripts/rosie.spec.js
@@ -77,6 +77,17 @@ describe('Factory', function() {
           .toThrowError(Error, 'The "nothing" factory is not defined.');
       });
     });
+
+    describe('changing deep attributes of a built object', function() {
+      it('should not change the factory definition', function() {
+        Factory.define('thing').attr('some', {'other': 'Thing 1'});
+        var newThing = Factory.build('thing');
+
+        newThing.some.other = 'Thing 5';
+
+        expect(Factory.build('thing')).toEqual({some: {other: 'Thing 1'}});
+      });
+    });
   });
 
   describe('buildList', function () {

--- a/src/rosie.js
+++ b/src/rosie.js
@@ -319,7 +319,7 @@ Factory.prototype = {
    * @return {*}
    */
   build: function(attributes, options) {
-    var result = this.attributes(attributes, options);
+    var result = Factory.util.deepClone(this.attributes(attributes, options));
     var retval = null;
 
     if (this.construct) {
@@ -399,6 +399,17 @@ Factory.util = (function() {
         }
       }
       return dest;
+    },
+
+    /**
+     * Deep clones given object.
+     *
+     * @private
+     * @param {object} object
+     * @return {object}
+     */
+    deepClone: function(object) {
+      return JSON.parse(JSON.stringify(object));
     }
   };
 })();


### PR DESCRIPTION
 - Prevents factory definition from also changing when the deep attributes of
   a built instance is changed.