### PR TITLE
update post build to return result of callback if have

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Factory.build('coach', {}, {buildPlayer: true});
 
 Multiple callbacks can be registered, and they will be executed in the order they are registered. The callbacks can manipulate the built object before it is returned to the callee.
 
+If the callback doesn't return anything, rosie will return build object as final result. If the callback returns a value, rosie will use that as final result instead.
+
 ### Associate a Factory with an existing Class
 
 This is an advanced use case that you can probably happily ignore, but store this away in case you need it.

--- a/spec/javascripts/rosie.spec.js
+++ b/spec/javascripts/rosie.spec.js
@@ -59,7 +59,7 @@ describe('Factory', function() {
             expect(Factory.build('thing').afterCalled).toBe(true);
           });
 
-          it('should pass options to the after callback', function(){
+          it('should pass options to the after callback', function() {
             expect(Factory.build('thing').isAwesomeOption).toBe(true);
           });
 
@@ -111,7 +111,7 @@ describe('Factory', function() {
     });
   });
 
-  describe('buildList', function () {
+  describe('buildList', function() {
     beforeEach(function() {
       Factory.define('thing').attr('name', 'Thing 1');
     });

--- a/spec/javascripts/rosie.spec.js
+++ b/spec/javascripts/rosie.spec.js
@@ -27,19 +27,51 @@ describe('Factory', function() {
       });
 
       describe('running callbacks', function() {
-        beforeEach(function() {
-          Factory.define('thing', Thing).option('isAwesome', true).after(function(obj, options) {
-            obj.afterCalled = true;
-            obj.isAwesomeOption = options.isAwesome;
+        describe('callbacks do not return value', function() {
+          beforeEach(function() {
+            Factory.define('thing', Thing).option('isAwesome', true).after(function(obj, options) {
+              obj.afterCalled = true;
+              obj.isAwesomeOption = options.isAwesome;
+            });
+          });
+
+          it('should run callbacks', function() {
+            expect(Factory.build('thing').afterCalled).toBe(true);
+          });
+
+          it('should pass options to the after callback', function(){
+            expect(Factory.build('thing').isAwesomeOption).toBe(true);
           });
         });
 
-        it('should run callbacks', function() {
-          expect(Factory.build('thing').afterCalled).toBe(true);
-        });
+        describe('callbacks return new object', function() {
+          beforeEach(function() {
+            Factory.define('thing', Thing).option('isAwesome', true).attr('name', 'Thing 1').after(function(obj, options) {
+              return {
+                afterCalled: true,
+                isAwesomeOption: options.isAwesome,
+                wrapped: obj
+              };
+            });
+          });
 
-        it('should pass options to the after callback', function(){
-          expect(Factory.build('thing').isAwesomeOption).toBe(true);
+          it('should run callbacks', function() {
+            expect(Factory.build('thing').afterCalled).toBe(true);
+          });
+
+          it('should pass options to the after callback', function(){
+            expect(Factory.build('thing').isAwesomeOption).toBe(true);
+          });
+
+          it('should return object from callback as the final result', function() {
+            expect(Factory.build('thing')).toEqual({
+              afterCalled: true,
+              isAwesomeOption: true,
+              wrapped: new Thing({
+                name: 'Thing 1'
+              })
+            });
+          });
         });
       });
 

--- a/src/rosie.js
+++ b/src/rosie.js
@@ -330,7 +330,8 @@ Factory.prototype = {
     }
 
     for (var i = 0; i < this.callbacks.length; i++) {
-      this.callbacks[i](retval, this.options(options));
+      var callbackResult = this.callbacks[i](retval, this.options(options));
+      retval = callbackResult || retval;
     }
     return retval;
   },


### PR DESCRIPTION
Hi,

Please help to review my PR. 
In my current project, I'm using rosie to create test data for Sequelize model. I thought I could use post build callback to wrap result of rosie factory in Sequelize model but the callbacks simply mutate the build object at the moment, there's no option to return a new object as the result of callback instead.

So I created this PR to implement that. I still keep the original behaviour if the callback doesn't return anything. If the callback returns something, it will take that returned value as final result instead.

In my opinion, it's also a bit cleaner to return new object instead of mutating existing build object as well

Thanks