### PR TITLE
semicolon is missing in document

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Factory.define('game')
 
 Factory.define('player')
   .sequence('id')
-  .sequence('name', function(i) { return 'player' + i; });
+  .sequence('name', function(i) { return 'player' + i; })
 
   // Define `position` to depend on `id`.
   .attr('position', ['id'], function(id) {


### PR DESCRIPTION
Semicolon is missing in README.md.

- [x] yarn test