### PR TITLE
Support generator dependencies in `attrs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ Factory.define('game')
   .sequence('id')
   .attrs({
     is_over: false,
-    created_at: () => new Date(),
-    random_seed: () => Math.random()
+    created_at: () => new Date().valueOf(),
+    random_seed: () => Math.random(),
+    updated_at: (created_at, random_seed) => created_at + random_seed
   })
   .attr('players', ['players'], players => {
     /* etc. */
@@ -267,7 +268,7 @@ Use this as a convenience function instead of calling `instance.attr` multiple t
 
 - **instance.attrs(`{attribute_1: value_1, attribute_2: value_2, ...}`)** - `attribute_i` is a string, `value_i` is either an object or generator function.
 
-See `instance.attr` above for details. Note: there is no way to specify dependencies using this method, so if you need that, you should use `instance.attr` instead.
+See `instance.attr` above for details.
 
 #### instance.option:
 

--- a/src/__tests__/rosie.test.js
+++ b/src/__tests__/rosie.test.js
@@ -91,7 +91,10 @@ describe('Factory', function() {
           Factory.define('thing', Thing).attrs({
             name: 'Thing 1',
             attr1: 'value1',
-            attr2: 'value2'
+            attr2: 'value2',
+            attr3: function(attr1, attr2) {
+              return attr1 + attr2;
+            }
           });
         });
 
@@ -101,7 +104,8 @@ describe('Factory', function() {
             expect.objectContaining({
               name: 'Thing 1',
               attr1: 'value1',
-              attr2: 'value2'
+              attr2: 'value2',
+              attr3: 'value1value2'
             })
           );
         });
@@ -612,6 +616,36 @@ describe('Factory', function() {
           'MADELINE'
         );
         expect(useCapsLockValues).toEqual([false, true]);
+      });
+    });
+  });
+
+  describe('util', function() {
+    describe('parseArgs', function() {
+      var testCases = {
+        'function (a,b,c) {}': ['a', 'b', 'c'],
+        'function () {}': [],
+        'function named(a, b, c) {}': ['a', 'b', 'c'],
+        'function (a /* = 1 */, b /* = true */) {}': ['a', 'b'],
+        'function fprintf(handle, fmt /*, ...*/) {}': ['handle', 'fmt'],
+        'function( a, b = 1, c ) {}': ['a', 'b', 'c'],
+        'function (a=4*(5/3), b) {}': ['a', 'b'],
+        'function (a, // single-line comment xjunk\nb) {}': ['a', 'b'],
+        'function (a /* function() yes */, \n /* no, */b)/* omg! */ {}': [
+          'a',
+          'b'
+        ],
+        'function ( A, b \n,c ,d \n ) \n {}': ['A', 'b', 'c', 'd'],
+        'function (a,b) {}': ['a', 'b'],
+        null: ['null'],
+        'function Object() {}': []
+      };
+
+      Object.keys(testCases).forEach(function(fn) {
+        it('should parseArgs from "' + fn + '"', function() {
+          var result = testCases[fn];
+          expect(Factory.util.parseArgs(fn)).toEqual(result);
+        });
       });
     });
   });


### PR DESCRIPTION
Allows dependencies to be provided when using the `attrs` api.  The arguments are extracted from the function using `toString()` and a series of regular expressions.  This should work for most use cases.