### PR TITLE
add failing test for option attr/sequence deps

### DIFF
--- a/src/__tests__/rosie.test.js
+++ b/src/__tests__/rosie.test.js
@@ -613,6 +613,28 @@ describe('Factory', function() {
         );
         expect(useCapsLockValues).toEqual([false, true]);
       });
+
+      it('should support attribute and sequence dependencies', function() {
+        factory.sequence('Id');
+        factory.option('name', ['Id'], function(id) {
+          return 'Object #' + id;
+        });
+        factory.attr('Meta', ['name'], function(name) {
+          return { Name: name };
+        });
+        expect(factory.build()).toEqual({
+          Id: 1,
+          Meta: {
+            Name: 'Object #1'
+          }
+        });
+        expect(factory.build({ Name: 'Custom Name' })).toEqual({
+          Id: 2,
+          Meta: {
+            Name: 'Custom Name'
+          }
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Option docs say

> dependencies is an array of strings, each string is the name of an attribute or option that is required by the generator_function

But it looks like only the options themselves are inspected to satisfy option dependencies. Am I misunderstanding something or is the test case valid?

```
● Factory › prototype › option › should support attribute and sequence dependencies

    TypeError: Cannot read property 'builder' of undefined

      290 | 
      291 |     var optMeta = this.opts[opt];
    > 292 |     if (!optMeta.builder) {
          |                  ^
      293 |       throw new Error(
      294 |         'option `' + opt + '` has no default value and none was provided'
      295 |       );

      at Factory.builder [as _optionValue] (src/rosie.js:292:18)
```