### PR TITLE
improve: Error handling if dependency does not exist

### DIFF
--- a/src/rosie.js
+++ b/src/rosie.js
@@ -238,6 +238,7 @@ class Factory {
    * @return {boolean}
    */
   _alwaysCallBuilder(attr) {
+    if (typeof this._attrs[attr] === 'undefined') throw new Error(`Dependency ${attr} does not exist, is the attribute or option defined?`);
     const attrMeta = this._attrs[attr];
     return attrMeta.dependencies.indexOf(attr) >= 0;
   }


### PR DESCRIPTION
Currently if you have a typo when defining dependencies you will get a very generic error that is not helpful in figuring out what is wrong. Added an error to be thrown to fix that issue.