### PR TITLE
Only run option builders once per `.build()` call

### DIFF
--- a/src/__tests__/rosie.test.js
+++ b/src/__tests__/rosie.test.js
@@ -147,7 +147,7 @@ describe('Factory', () => {
               option: 'default value',
               value: 'default value',
             });
-            expect(fn).toHaveBeenCalled();
+            expect(fn).toHaveBeenCalledTimes(1);
           });
         });
       });

--- a/src/rosie.js
+++ b/src/rosie.js
@@ -307,6 +307,10 @@ class Factory {
    * @return {*}
    */
   build(attributes, options) {
+    // Precalculate options.
+    // Because options cannot depend on themselves or on attributes, subsequent calls to
+    // `this.options` will be idempotent and we can avoid re-running builders
+    options = this.options(options);
     const result = this.attributes(attributes, options);
     let retval = null;
 
@@ -318,7 +322,7 @@ class Factory {
     }
 
     for (let i = 0; i < this.callbacks.length; i++) {
-      const callbackResult = this.callbacks[i](retval, this.options(options));
+      const callbackResult = this.callbacks[i](retval, options);
       retval = callbackResult || retval;
     }
     return retval;


### PR DESCRIPTION
This might be a bit niche, but we're using Rosie to build fairly complicated network mocks and this issue was causing some very strange behaviour!