### PR TITLE
Supports Async callback

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "es2021": true
+  },
   "extends": ["eslint:recommended", "prettier"],
   "plugins": ["jest"],
   "parserOptions": {

--- a/src/__tests__/rosie.test.js
+++ b/src/__tests__/rosie.test.js
@@ -386,11 +386,15 @@ describe('Factory', () => {
       });
 
       it('throws error if the factory is not defined', async () => {
+        let error;
         try {
           await Factory.buildAsync('nothing');
         } catch (e) {
-          expect(e).toEqual(new Error('The "nothing" factory is not defined.'));
+          error = e;
         }
+        expect(error).toEqual(
+          new Error('The "nothing" factory is not defined.')
+        );
       });
     });
   });


### PR DESCRIPTION
`.after()` function now supports async function.

After that we can call `await buildAsync()` and `await buildListAsync()` function.